### PR TITLE
Add new article: L'avenir du blog / The Future of This Blog

### DIFF
--- a/_i18n/en/_posts/2026-08-17-avenir-du-blog.md
+++ b/_i18n/en/_posts/2026-08-17-avenir-du-blog.md
@@ -4,42 +4,44 @@ title: "The Future of This Blog"
 date:   2026-08-17 08:00:00
 categories: other
 lang: en
-resume: "After several months away, this blog is starting again, but from a different angle: practice rather than theory. This article announces the end of the Logbook of Learning Domain-Driven Design, the start of a series on developing a complete project, Agojie, and the place AI will hold in it."
+resume: "After several months on hold, this blog is starting again, but from a different angle: practice rather than theory. This article announces the end of the Logbook of Learning Domain-Driven Design, the start of a series on developing a complete project, Agojie, and the role AI will play in it."
 permalink: /other/2026-08-17
 ---
 
 Welcome back!
 
-After several months away from this blog, I have finally decided to get back to it. I thought long and hard about what I wanted to write about, because with the arrival of AI I had the feeling that writing articles no longer served any purpose. Most knowledge is available quickly, without having to read an article all the way through.
+After several months on hold, I’ve finally decided to get back to this blog. I thought long and hard about what I wanted to write about, because with the rise of AI I had the feeling that writing articles no longer served any purpose: most knowledge is available quickly, without having to read an article all the way through.
 
-I realized that, first, I missed it (because it forces me to keep learning and practicing in order to be able to write), and also that I still had things to say. Not necessarily about theory, because you can find a great many people who have written about my favorite subjects (**DDD**, **hexagonal architecture**, and so on), and because I do not want to do what many people do: ask an AI to write an article from someone else’s text. About practice, rather.
+I realized that I missed it (because it forces me to keep learning and practicing so I can write) and that I still had things to say. Not necessarily about theory, because plenty of people have already written about my favorite subjects (**DDD**, **Hexagonal Architecture**, and so on), and because I don’t want to do what so many others are doing: ask an AI to write an article from someone else’s text. But about practice instead.
 
-I find that we do not see enough concrete, end-to-end examples. Like the article I wrote on pagination with **DDD** and **hexagonal architecture**. So that is what my future articles will be about: practice.
+I find that we don’t see enough concrete, end-to-end examples, like the [article I wrote on pagination](https://huguesgobet.com/other/2024-12-16) with **DDD** and **Hexagonal Architecture**. So that’s what my future articles will be about: practice.
 
 ## What Comes Next
 
-I am going to stop the **Logbook of Learning Domain-Driven Design** series, because I was writing after developing, and it was hard to maintain the repository in a state that showed concrete examples matching the stage I was actually at.
+I’m going to stop the **Logbook of Learning Domain-Driven Design** series, because I was writing after developing, and it was hard to keep the repository at the exact stage I had reached in the article.
 
-I am, however, going to start a series on developing a complete project in **DDD**. The advantage of this project is that it has not been started yet, so it will be easier to write up as I go. I will also keep writing special articles on modeling subjects encountered in my work.
+However, I’m going to start a series on developing a complete project in **DDD**. The advantage of this project is that it hasn’t been started yet, so it’ll be easier to tell as I go. I’ll also keep writing special editions on modeling problems I run into at work.
 
-By the end of the year, I would also like to give my first conference talk, either on the project written in **DDD**, or on cases encountered in my work.
+By the end of the year, I’d also like to give my first conference talk, either on the project built with **DDD** or on cases I’ve had to deal with at work.
 
 ## The Project in Question: Agojie
 
-Now it is time to tell you a little more about the project the series will be about. The idea is to automate **Dice Throne**, a board game I discovered on vacation. It is a turn-based character combat game played with dice. The advantages of this game are the modeling challenges it raises, as well as the variety of characters (more than twenty as I write these lines), which requires an adaptable model, one that allows different abilities to be added without having to change everything all over again.
+Now it’s time to say a little more about the project the series will follow. The **Agojie** were an all-female military regiment of the Fon people, in the Kingdom of Dahomey. All my new projects are named after something connected to King Tegbessou, a figure I have a particular attachment to.
+
+The idea is to automate **Dice Throne**, a board game I discovered on vacation. It’s a turn-based combat game between characters, played with dice. What interests me about this game are its modeling challenges and the variety of its characters (more than twenty at the time of writing): that variety requires an adaptable model, one that can take on new abilities without having to remodel everything.
 
 ## Using AI
 
-Like many people in our time, I think AI is too important to be ignored. This project will therefore be developed with the help of AI, following very precise skills that I wrote in order to move the project forward faster. If I do not use AI, the project will never move at a pace sufficient to write one article a month.
+Like many people these days, I think AI is too important to ignore. This project will therefore be developed with the help of AI, following very precise skills (processes that frame what an AI does according to a precise protocol) that I wrote in order to move the project forward faster. If I don’t use AI, the project will never move fast enough for me to write one article a month.
 
-AI will also be used, in part, to correct the spelling, grammar and conjugation mistakes in these articles, but I will always be their author. There is no question of telling the AI “write me an article on this subject”. That would be of no interest, and it would not be like me.
+AI will also be used, in part, to correct the spelling and grammar mistakes in these articles, but I’ll always be their author. I’m not going to tell the AI, “Write me an article on such-and-such a topic.” There would be no point in that, and it wouldn’t be like me.
 
-Should anyone be interested in the skills used for correction or for development, I can provide them, but it is not the purpose of this blog to provide knowledge about AI.
+If anyone is interested in the skills used for correction or for development, I can share them, but this blog isn’t meant to be about AI.
 
 ## The Plan
 
-The plan is that the next article will come out in about a month, to give me time to move the project forward and to write something that holds things worth reading, and worth writing for me.
+The next article will come out in about a month, giving me time to move the project forward and to write something worth reading, and, for me, worth writing.
 
 ## Your Feedback
 
-I will gladly take any positive or constructive comment. The rest, I could not care less about, and I will not waste my time replying to you. I am open to discussion about modeling and about writing.
+I’ll gladly take any positive or constructive comments. The rest, I couldn’t care less about, and I won’t waste my time replying to them. I’m open to discussion about modeling and writing.

--- a/_i18n/en/_posts/2026-08-17-avenir-du-blog.md
+++ b/_i18n/en/_posts/2026-08-17-avenir-du-blog.md
@@ -1,0 +1,45 @@
+---
+layout: article
+title: "The Future of This Blog"
+date:   2026-08-17 08:00:00
+categories: other
+lang: en
+resume: "After several months away, this blog is starting again, but from a different angle: practice rather than theory. This article announces the end of the Logbook of Learning Domain-Driven Design, the start of a series on developing a complete project, Agojie, and the place AI will hold in it."
+permalink: /other/2026-08-17
+---
+
+Welcome back!
+
+After several months away from this blog, I have finally decided to get back to it. I thought long and hard about what I wanted to write about, because with the arrival of AI I had the feeling that writing articles no longer served any purpose. Most knowledge is available quickly, without having to read an article all the way through.
+
+I realized that, first, I missed it (because it forces me to keep learning and practicing in order to be able to write), and also that I still had things to say. Not necessarily about theory, because you can find a great many people who have written about my favorite subjects (**DDD**, **hexagonal architecture**, and so on), and because I do not want to do what many people do: ask an AI to write an article from someone else’s text. About practice, rather.
+
+I find that we do not see enough concrete, end-to-end examples. Like the article I wrote on pagination with **DDD** and **hexagonal architecture**. So that is what my future articles will be about: practice.
+
+## What Comes Next
+
+I am going to stop the **Logbook of Learning Domain-Driven Design** series, because I was writing after developing, and it was hard to maintain the repository in a state that showed concrete examples matching the stage I was actually at.
+
+I am, however, going to start a series on developing a complete project in **DDD**. The advantage of this project is that it has not been started yet, so it will be easier to write up as I go. I will also keep writing special articles on modeling subjects encountered in my work.
+
+By the end of the year, I would also like to give my first conference talk, either on the project written in **DDD**, or on cases encountered in my work.
+
+## The Project in Question: Agojie
+
+Now it is time to tell you a little more about the project the series will be about. The idea is to automate **Dice Throne**, a board game I discovered on vacation. It is a turn-based character combat game played with dice. The advantages of this game are the modeling challenges it raises, as well as the variety of characters (more than twenty as I write these lines), which requires an adaptable model, one that allows different abilities to be added without having to change everything all over again.
+
+## Using AI
+
+Like many people in our time, I think AI is too important to be ignored. This project will therefore be developed with the help of AI, following very precise skills that I wrote in order to move the project forward faster. If I do not use AI, the project will never move at a pace sufficient to write one article a month.
+
+AI will also be used, in part, to correct the spelling, grammar and conjugation mistakes in these articles, but I will always be their author. There is no question of telling the AI “write me an article on this subject”. That would be of no interest, and it would not be like me.
+
+Should anyone be interested in the skills used for correction or for development, I can provide them, but it is not the purpose of this blog to provide knowledge about AI.
+
+## The Plan
+
+The plan is that the next article will come out in about a month, to give me time to move the project forward and to write something that holds things worth reading, and worth writing for me.
+
+## Your Feedback
+
+I will gladly take any positive or constructive comment. The rest, I could not care less about, and I will not waste my time replying to you. I am open to discussion about modeling and about writing.

--- a/_i18n/fr/_posts/2026-08-17-avenir-du-blog.md
+++ b/_i18n/fr/_posts/2026-08-17-avenir-du-blog.md
@@ -10,36 +10,38 @@ permalink: /other/2026-08-17
 
 Welcome back!
 
-Après plusieurs mois d’arrêt de ce blog, je décide enfin de m’y remettre. J’ai longuement réfléchi à ce sur quoi je voulais écrire, car avec l’arrivée de l’IA j’avais l’impression qu’écrire des articles ne servait plus à rien. Vu que la plupart des connaissances sont disponibles rapidement et sans avoir besoin de lire un article jusqu’au bout.
+Après plusieurs mois d’arrêt, je décide enfin de m’y remettre. J’ai longuement réfléchi à ce sur quoi je voulais écrire, car avec l’arrivée de l’IA j’avais l’impression qu’écrire des articles ne servait plus à rien : la plupart des connaissances sont disponibles rapidement, sans avoir besoin de lire un article jusqu’au bout.
 
-Je me suis rendu compte que, premièrement, ça me manquait (parce que ça me force à continuer d’apprendre et de pratiquer pour pouvoir écrire) et aussi que j’avais encore des choses à dire. Pas forcément sur la théorie, parce qu’on peut trouver énormément de gens qui ont écrit sur mes sujets de prédilection (**DDD**, **architecture hexagonale**…) et que je n’ai pas envie de faire comme beaucoup font : demander à l’IA d’écrire un article depuis le texte de quelqu’un d’autre. Mais plutôt sur la pratique.
+Je me suis rendu compte que ça me manquait (parce que ça me force à continuer d’apprendre et de pratiquer pour pouvoir écrire) et que j’avais encore des choses à dire. Pas forcément sur la théorie, parce qu’énormément de gens ont déjà écrit sur mes sujets de prédilection (**DDD**, **Architecture Hexagonale**…) et que je n’ai pas envie de faire ce que beaucoup font : demander à l’IA d’écrire un article à partir du texte de quelqu’un d’autre. Mais plutôt sur la pratique.
 
-Je trouve qu’on ne voit pas assez d’exemples concrets de bout en bout. Comme l’article que j’avais écrit sur la pagination avec du **DDD** et de l’**architecture hexagonale**. Donc voilà sur quoi vont porter mes futurs articles : la pratique.
+Je trouve qu’on ne voit pas assez d’exemples concrets de bout en bout, comme l’[article que j’avais écrit sur la pagination](https://huguesgobet.com/fr/other/2024-12-16) avec du **DDD** et de l’**Architecture Hexagonale**. Donc voilà sur quoi vont porter mes futurs articles : la pratique.
 
 ## La suite
 
-Je vais arrêter la série du **Journal de bord d’apprentissage du Domain-Driven Design**, parce que j’écrivais après avoir développé et c’était dur de maintenir le repository pour montrer des exemples concrets qui étaient vraiment à l’étape où j’en étais.
+Je vais arrêter la série du **Journal de bord d’apprentissage du Domain-Driven Design**, parce que j’écrivais après avoir développé, et c’était dur de maintenir le repository à l’étape exacte où j’en étais dans l’article.
 
-Par contre, je vais commencer une série sur le développement d’un projet complet en **DDD**. L’avantage de ce projet, c’est qu’il n’est pas commencé, il sera donc plus facile à retranscrire. Je vais aussi continuer d’écrire des hors-série sur des sujets de modélisation rencontrés dans mon travail.
+Par contre, je vais commencer une série sur le développement d’un projet complet en **DDD**. L’avantage de ce projet, c’est qu’il n’est pas commencé : il sera donc plus facile à raconter. Je vais aussi continuer d’écrire des hors-série sur des sujets de modélisation rencontrés dans mon travail.
 
-J’aimerais aussi, d’ici la fin de l’année, faire ma première conférence, soit sur le sujet du projet écrit en **DDD**, soit sur des cas rencontrés dans mon travail.
+J’aimerais aussi, d’ici la fin de l’année, faire ma première conférence, soit sur le sujet du projet écrit en **DDD**, soit sur des cas auxquels j’ai été confronté dans mon travail.
 
 ## Le projet en question : Agojie
 
-Maintenant, il est temps de vous parler un peu plus du projet sur lequel la série portera. L’idée est d’automatiser **Dice Throne**, un jeu de société que j’ai découvert en vacances. C’est un jeu de combat au tour par tour de personnages qui se joue avec des dés. Les avantages de ce jeu sont les enjeux de modélisation, ainsi que la variété des personnages (plus d’une vingtaine à l’heure où j’écris ces lignes) qui oblige à un modèle adaptable pour pouvoir rajouter différentes compétences sans devoir tout re-modifier.
+Maintenant, il est temps de vous parler un peu plus du projet sur lequel la série portera. Les **Agojie** étaient un ancien régiment militaire entièrement féminin du peuple Fon, dans le royaume du Dahomey. Tous les noms de mes nouveaux projets sont liés au roi Tegbessou, un personnage pour qui j’ai un affect particulier.
+
+L’idée est d’automatiser **Dice Throne**, un jeu de société que j’ai découvert en vacances. C’est un jeu de combat entre personnages, au tour par tour, qui se joue avec des dés. Ce jeu m’intéresse pour ses enjeux de modélisation et pour la variété de ses personnages (plus d’une vingtaine à l’heure où j’écris ces lignes) : elle oblige à un modèle adaptable, capable d’accueillir de nouvelles compétences sans tout remodéliser.
 
 ## L’utilisation de l’IA
 
-Comme beaucoup à notre époque, je pense que l’IA est trop importante pour être ignorée. Ce projet sera donc développé avec l’aide de l’IA, en suivant des skills très précis que j’ai écrits dans le but d’avancer le projet plus rapidement. Si je n’utilise pas l’IA, le projet n’avancera jamais à un rythme suffisant pour pouvoir écrire un article par mois.
+Comme beaucoup à notre époque, je pense que l’IA est trop importante pour être ignorée. Ce projet sera donc développé avec l’aide de l’IA, en suivant des skills (des processus qui cadrent les actions d’une IA selon un protocole précis) que j’ai écrits dans le but d’avancer le projet plus rapidement. Si je n’utilise pas l’IA, le projet n’avancera jamais à un rythme suffisant pour écrire un article par mois.
 
-L’IA sera aussi utilisée en partie pour corriger les fautes d’orthographe, de grammaire et de conjugaison de ces articles, mais j’en serai toujours l’auteur. Il n’est pas question de dire à l’IA « écris-moi un article sur tel sujet », ça n’aurait aucun intérêt et ça ne me ressemblerait pas.
+L’IA servira aussi à corriger les fautes d’orthographe, de grammaire et de conjugaison de ces articles, mais j’en serai toujours l’auteur. Il n’est pas question de dire à l’IA « écris-moi un article sur tel sujet », ça n’aurait aucun intérêt et ça ne me ressemblerait pas.
 
-Si jamais certains sont intéressés par les skills utilisés pour la correction ou le développement, je pourrai les fournir, mais ce n’est pas le but de ce blog de fournir des connaissances sur l’IA.
+Si jamais certains sont intéressés par les skills utilisés pour la correction ou le développement, je pourrai les partager, mais ce blog n’a pas vocation à parler d’IA.
 
 ## Programme
 
-Le programme est que le prochain article sortira dans environ un mois, pour prendre le temps d’avancer le projet et d’écrire quelque chose qui contiendra des choses intéressantes à lire, et pour moi à écrire.
+Le prochain article sortira dans environ un mois, le temps d’avancer sur le projet et d’écrire quelque chose d’intéressant à lire, et pour moi à écrire.
 
 ## Vos retours
 
-Je prendrai tous les commentaires positifs ou constructifs avec plaisir. Les autres, je m’en fiche royalement et je ne perdrai pas mon temps à vous répondre. Je suis ouvert à la discussion sur la modélisation et l’écriture.
+Je prendrai avec plaisir tous les commentaires positifs ou constructifs. Les autres, je m’en fiche royalement et je ne perdrai pas mon temps à y répondre. Je suis ouvert à la discussion sur la modélisation et l’écriture.

--- a/_i18n/fr/_posts/2026-08-17-avenir-du-blog.md
+++ b/_i18n/fr/_posts/2026-08-17-avenir-du-blog.md
@@ -1,0 +1,45 @@
+---
+layout: article
+title: "L’avenir du blog"
+date:   2026-08-17 08:00:00
+categories: other
+lang: fr
+resume: "Après plusieurs mois d’arrêt, ce blog reprend, mais sur un autre angle : la pratique plutôt que la théorie. Cet article annonce la fin du journal de bord d’apprentissage du DDD, le démarrage d’une série sur le développement complet d’un projet, Agojie, et la place que l’IA y tiendra."
+permalink: /other/2026-08-17
+---
+
+Welcome back!
+
+Après plusieurs mois d’arrêt de ce blog, je décide enfin de m’y remettre. J’ai longuement réfléchi à ce sur quoi je voulais écrire, car avec l’arrivée de l’IA j’avais l’impression qu’écrire des articles ne servait plus à rien. Vu que la plupart des connaissances sont disponibles rapidement et sans avoir besoin de lire un article jusqu’au bout.
+
+Je me suis rendu compte que, premièrement, ça me manquait (parce que ça me force à continuer d’apprendre et de pratiquer pour pouvoir écrire) et aussi que j’avais encore des choses à dire. Pas forcément sur la théorie, parce qu’on peut trouver énormément de gens qui ont écrit sur mes sujets de prédilection (**DDD**, **architecture hexagonale**…) et que je n’ai pas envie de faire comme beaucoup font : demander à l’IA d’écrire un article depuis le texte de quelqu’un d’autre. Mais plutôt sur la pratique.
+
+Je trouve qu’on ne voit pas assez d’exemples concrets de bout en bout. Comme l’article que j’avais écrit sur la pagination avec du **DDD** et de l’**architecture hexagonale**. Donc voilà sur quoi vont porter mes futurs articles : la pratique.
+
+## La suite
+
+Je vais arrêter la série du **Journal de bord d’apprentissage du Domain-Driven Design**, parce que j’écrivais après avoir développé et c’était dur de maintenir le repository pour montrer des exemples concrets qui étaient vraiment à l’étape où j’en étais.
+
+Par contre, je vais commencer une série sur le développement d’un projet complet en **DDD**. L’avantage de ce projet, c’est qu’il n’est pas commencé, il sera donc plus facile à retranscrire. Je vais aussi continuer d’écrire des hors-série sur des sujets de modélisation rencontrés dans mon travail.
+
+J’aimerais aussi, d’ici la fin de l’année, faire ma première conférence, soit sur le sujet du projet écrit en **DDD**, soit sur des cas rencontrés dans mon travail.
+
+## Le projet en question : Agojie
+
+Maintenant, il est temps de vous parler un peu plus du projet sur lequel la série portera. L’idée est d’automatiser **Dice Throne**, un jeu de société que j’ai découvert en vacances. C’est un jeu de combat au tour par tour de personnages qui se joue avec des dés. Les avantages de ce jeu sont les enjeux de modélisation, ainsi que la variété des personnages (plus d’une vingtaine à l’heure où j’écris ces lignes) qui oblige à un modèle adaptable pour pouvoir rajouter différentes compétences sans devoir tout re-modifier.
+
+## L’utilisation de l’IA
+
+Comme beaucoup à notre époque, je pense que l’IA est trop importante pour être ignorée. Ce projet sera donc développé avec l’aide de l’IA, en suivant des skills très précis que j’ai écrits dans le but d’avancer le projet plus rapidement. Si je n’utilise pas l’IA, le projet n’avancera jamais à un rythme suffisant pour pouvoir écrire un article par mois.
+
+L’IA sera aussi utilisée en partie pour corriger les fautes d’orthographe, de grammaire et de conjugaison de ces articles, mais j’en serai toujours l’auteur. Il n’est pas question de dire à l’IA « écris-moi un article sur tel sujet », ça n’aurait aucun intérêt et ça ne me ressemblerait pas.
+
+Si jamais certains sont intéressés par les skills utilisés pour la correction ou le développement, je pourrai les fournir, mais ce n’est pas le but de ce blog de fournir des connaissances sur l’IA.
+
+## Programme
+
+Le programme est que le prochain article sortira dans environ un mois, pour prendre le temps d’avancer le projet et d’écrire quelque chose qui contiendra des choses intéressantes à lire, et pour moi à écrire.
+
+## Vos retours
+
+Je prendrai tous les commentaires positifs ou constructifs avec plaisir. Les autres, je m’en fiche royalement et je ne perdrai pas mon temps à vous répondre. Je suis ouvert à la discussion sur la modélisation et l’écriture.


### PR DESCRIPTION
Article d'ouverture de la reprise du blog, publié en hors-série (`categories: other`).

- `_i18n/fr/_posts/2026-08-17-avenir-du-blog.md`
- `_i18n/en/_posts/2026-08-17-avenir-du-blog.md`

Date de publication : 17 août 2026. Permalink `/other/2026-08-17`, donc listé sur la page `/other` sans autre fichier à modifier.

Contenu : fin de la série Journal de bord d'apprentissage du DDD, démarrage d'une série sur le développement complet d'un projet (Agojie, automatisation de Dice Throne), et place de l'IA dans la production des articles et du code.

Les deux versions ont été relues avant ouverture : passe de langue sur le français, passe anti-calque sur l'anglais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)