### PR TITLE
ci: build quotidien pour publier les articles à date future

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main  # Remplacez par votre branche principale si différente
+  # Build quotidien : Jekyll exclut les articles à date future (`future: false`),
+  # un article daté d'après son merge n'apparaît donc qu'au build suivant.
+  schedule:
+    - cron: '0 9 * * *'  # 09:00 UTC, après l'heure de publication des articles (08:00)
+  workflow_dispatch:
 
 jobs:
   build-deploy:


### PR DESCRIPTION
Jekyll n'inclut pas les articles à date future (`future: false` par défaut, la clé est absente de `_config.yml`). Le workflow ne se déclenchant que sur un push vers `main`, un article mergé avant sa date de publication reste invisible indéfiniment : aucun build ne le rattrape.

Ajoute deux déclencheurs :

- `schedule` à 09:00 UTC chaque jour, après l'heure de publication des articles (08:00), pour que la date du front matter suffise à programmer une sortie.
- `workflow_dispatch`, pour relancer un build à la main sans commit vide.

Rien d'autre ne change : mêmes étapes, même déploiement.

Note : GitHub désactive les workflows planifiés d'un dépôt sans activité pendant 60 jours. Un commit suffit à les réactiver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)